### PR TITLE
Fix: Disable function constructors for std types

### DIFF
--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -1497,7 +1497,7 @@ export class Pointer<T = any> extends Ref<T> {
                 // else
                 if (!allow_failure) displayFatalError('pointer-not-found');
                 pointer.delete();
-                throw new PointerError("Pointer $"+id_string+" has no assigned value", SCOPE);
+                throw new PointerError("Pointer $"+id_string+" does not exist", SCOPE);
             }
         }
 

--- a/runtime/runtime.ts
+++ b/runtime/runtime.ts
@@ -1806,6 +1806,10 @@ export class Runtime {
      * @param header DXB header of incoming message
      */
     private static updateEndpointOnlineState(header: dxb_header) {
+        if (!header) {
+            logger.error("updateEndpointOnlineState: no header provided");
+            return;
+        }
         if (header.sender) {
             // received signed GOODBYE message -> endpoint is offline
             if (header.type == ProtocolDataType.GOODBYE) {

--- a/types/function-utils.ts
+++ b/types/function-utils.ts
@@ -204,8 +204,8 @@ export function createFunctionWithDependencyInjections(source: string, dependenc
 }
 
 export class ExtensibleFunction {
-    constructor(f:globalThis.Function) {
-        return Object.setPrototypeOf(f, new.target.prototype);
+    constructor(f?:globalThis.Function) {
+        if (f) return Object.setPrototypeOf(f, new.target.prototype);
     }
 }
 

--- a/types/type.ts
+++ b/types/type.ts
@@ -1081,15 +1081,15 @@ Type.std.Assertion.setJSInterface({
 })
 
 
-Type.std.StorageMap.setJSInterface({
-    class: StorageMap,
+Type.std.StorageWeakMap.setJSInterface({
+    class: StorageWeakMap,
     is_normal_object: true,
     proxify_children: true,
     visible_children: new Set(),
 })
 
-Type.std.StorageWeakMap.setJSInterface({
-    class: StorageWeakMap,
+Type.std.StorageMap.setJSInterface({
+    class: StorageMap,
     is_normal_object: true,
     proxify_children: true,
     visible_children: new Set(),

--- a/types/type.ts
+++ b/types/type.ts
@@ -367,7 +367,7 @@ export class Type<T = any> extends ExtensibleFunction {
 
     // never call the constructor directly!! should be private
     constructor(namespace?:string, name?:string, variation?:string, parameters?:any[]) {
-        super((val:any) => this.cast(val))
+        super(namespace && namespace != "std" ? (val:any) => this.cast(val) : undefined)
         if (name) this.name = name;
         if (namespace) this.namespace = namespace;
         if (variation) this.variation = variation;


### PR DESCRIPTION
Currently, types for custom sync classes can be called as function to create new instances of the types:

```ts
@sync class MyClass {
  @property x = 0
}

const inst1 = MyClass({
  x: 1
})

const inst2 = Datex.Type.get("MyClass")({
  x: 2
})
```

This does not work correctly and is not necessary for std types, especially primitives:
```ts
const myText = Datex.Type.std.text("text") // not allowed
```

Because the prototype reasignment required to make a Datex type instance callable creates quite some unnecessary overhead, this should be disabled for all builtin std types.