### PR TITLE
Update dx config

### DIFF
--- a/docs/manual/03 Pointers.md
+++ b/docs/manual/03 Pointers.md
@@ -245,6 +245,32 @@ it is garbage colleted and the effect is removed.
 
 Weak value bindings can be used with all *object* values, not just with pointers.
 
+### Async effects
+
+Effect callbacks cannot be `async` functions.
+To handle async operations, you can always call an async function from inside the
+effect callback:
+
+```ts
+const searchName = $$("");
+const searchAge = $$(18);
+
+// async function that searches for a user and shows the result somewhere
+async function searchUser(name: string, age: number) {
+    const user = await query({type: "user", name, age});
+    showUser(user);
+}
+
+// effect that triggers the user search every time searchName or searchAge is changed
+effect(() => searchUser(searchName.val, searchAge.val))
+```
+
+All dependency values of the effect must be accessed synchronously.
+This means that the variables inside the async function don't trigger the effect, only the ones passed
+into the `searchUser` call.
+
+
+
 ## Observing pointer changes
 
 For more fine grained control, the `observe()` function can be used to handle pointer value updates.

--- a/docs/manual/03 Pointers.md
+++ b/docs/manual/03 Pointers.md
@@ -154,7 +154,7 @@ Read more about transform functions in the chapter [Functional Programming](./09
 
 ## Using effects
 
-With transform functions, value can be defined declaratively.
+With transform functions, values can be defined declaratively.
 Still, there are some scenarios where the actual pointer value change event must be handled with custom logic.
 For this scenario, the `effect()` function can be used.
 


### PR DESCRIPTION
Currently, when the backend endpoint for a domain changes, we get a network error on the clients because the still have the cached, outdated dx config file. The only way to get the clients to work again is to completely reset the app.

With this PR, the local dx config is automatically updated with changes from dx config file from the backend.
Existing local config entries (e.g. the endpoint) are preserved.