### PR TITLE
Add async effects and async always

### DIFF
--- a/compiler/compiler.ts
+++ b/compiler/compiler.ts
@@ -2017,7 +2017,8 @@ export class Compiler {
                 SCOPE.addJSTypeDefs = receiver != Runtime.endpoint && receiver != LOCAL_ENDPOINT;
             }
 
-            const addTypeDefs = SCOPE.addJSTypeDefs && jsTypeDefModule;
+            // add js type module only if http(s) url
+            const addTypeDefs = SCOPE.addJSTypeDefs && jsTypeDefModule && (jsTypeDefModule.toString().startsWith("http://") || jsTypeDefModule.toString().startsWith("https://"));
 
             if (addTypeDefs) {
                 Compiler.builder.handleRequiredBufferSize(SCOPE.b_index+4, SCOPE);

--- a/datex_short.ts
+++ b/datex_short.ts
@@ -5,7 +5,7 @@ import { baseURL, Runtime, PrecompiledDXB, Type, Pointer, Ref, PointerProperty, 
 
 /** make decorators global */
 import { assert as _assert, property as _property, sync as _sync, endpoint as _endpoint, template as _template, jsdoc as _jsdoc} from "./datex_all.ts";
-import { effect as _effect, always as _always, toggle as _toggle, map as _map, equals as _equals, selectProperty as _selectProperty, not as _not } from "./functions.ts";
+import { effect as _effect, always as _always, asyncAlways as _asyncAlways, toggle as _toggle, map as _map, equals as _equals, selectProperty as _selectProperty, not as _not } from "./functions.ts";
 export * from "./functions.ts";
 import { NOT_EXISTING, DX_SLOTS, SLOT_GET, SLOT_SET } from "./runtime/constants.ts";
 import { AssertionError } from "./types/errors.ts";
@@ -24,6 +24,7 @@ declare global {
 	const sync: typeof _sync;
 	const endpoint: typeof _endpoint;
     const always: typeof _always;
+    const asyncAlways: typeof _asyncAlways;
     const toggle: typeof _toggle;
     const map: typeof _map;
     const equals: typeof _equals;
@@ -611,6 +612,7 @@ export function translocate<T extends Map<unknown,unknown>|Set<unknown>|Array<un
 
 Object.defineProperty(globalThis, 'once', {value:once, configurable:false})
 Object.defineProperty(globalThis, 'always', {value:_always, configurable:false})
+Object.defineProperty(globalThis, 'asyncAlways', {value:_asyncAlways, configurable:false})
 Object.defineProperty(globalThis, 'toggle', {value:_toggle, configurable:false})
 Object.defineProperty(globalThis, 'map', {value:_map, configurable:false})
 Object.defineProperty(globalThis, 'equals', {value:_equals, configurable:false})

--- a/docs/manual/09 Functional Programming.md
+++ b/docs/manual/09 Functional Programming.md
@@ -84,7 +84,7 @@ c.val = 20;
 >  The `always` transform function must always be synchronous and must not return a Promise
 
 
-### Caching `always` output values
+## Caching `always` output values
 
 Since `always` functions are always required to be pure functions, it is possible to
 cache the result of a calculation with given input values and return it at a later point in time.
@@ -169,6 +169,35 @@ const urlContent = transformAsync([url], async url => (await fetch(url)).json())
 ```
 
 The same restrictions as for `transform` functions apply
+
+
+### The `asyncAlways` transform function
+
+The `asyncAlways` function is similar to the `always` function, but can be used for async transforms.
+The `asyncAlways` function does not accept `async` functions as transform functions, but allows promises as return values:
+
+```ts
+const input = $$(10);
+
+const output = await asyncAlways(() => input.val * 10)       // 🔶 Runtime warning: use 'always' instead
+const output = await asyncAlways(async () => input.val * 10) // ❌ Runtime error: asyncAlways cannot be used with async functions
+const output = await asyncAlways(() => (async () => input.val * 10)()) // ❌ No runtime error, but not recommended
+
+const fn = async () => {
+    const res = await asyncOperation();
+    return res + input.val // input is not captured here!
+}
+const output = await asyncAlways(() => fn()) // ❌ No runtime error, but 'output' is not recalculated when 'input' changes!
+
+const output = await asyncAlways(() => asyncFunction(input.val)) // ✅ Correct usage
+const output = await asyncAlways(() => (async (val) => val * 10)(input.val) ) // ✅ Correct usage
+``` 
+
+> [!NOTE]
+> In some cases, async transform functions would work correctly with `asyncAlways`, but
+> any dependency value after the first `await` is not captured. 
+> To avoid confusion, async transform functions are always disallowed for `asyncAlways`.
+
 
 ## Dedicated transform functions
 

--- a/functions.ts
+++ b/functions.ts
@@ -4,7 +4,7 @@
  */
 
 
-import { AsyncTransformFunction, BooleanRef, CollapsedValue, CollapsedValueAdvanced, Decorators, INSERT_MARK, METADATA, MaybeObjectRef, MinimalJSRef, Pointer, Ref, RefLike, RefOrValue, Runtime, SmartTransformFunction, SmartTransformOptions, TransformFunction, TransformFunctionInputs, handleDecoratorArgs, primitive } from "./datex_all.ts";
+import { AsyncTransformFunction, BooleanRef, CollapsedValue, CollapsedValueAdvanced, Decorators, INSERT_MARK, METADATA, MaybeObjectRef, MinimalJSRef, Pointer, Ref, RefLike, RefOrValue, Runtime, SmartTransformFunction, SmartTransformOptions, TransformFunction, TransformFunctionInputs, handleDecoratorArgs, logger, primitive } from "./datex_all.ts";
 import { Datex } from "./mod.ts";
 import { PointerError } from "./types/errors.ts";
 import { IterableHandler } from "./utils/iterable-handler.ts";
@@ -71,7 +71,10 @@ export async function asyncAlways<T>(transform:SmartTransformFunction<T>, option
 	}
 	const ptr = Pointer.createSmartTransform(transform, undefined, undefined, undefined, options);
 	if (!ptr.value_initialized && ptr.waiting_for_always_promise) {
-		await new Promise<void>((resolve) => ptr.always_promise_resolve_callback = resolve);
+		await ptr.waiting_for_always_promise;
+	}
+	else {
+		logger.warn("asyncAlways: transform function did not return a Promise, you should use 'always' instead")
 	}
 	return Ref.collapseValue(ptr) as MinimalJSRef<T>
 }

--- a/functions.ts
+++ b/functions.ts
@@ -55,9 +55,14 @@ export function always(scriptOrJSTransform:TemplateStringsArray|SmartTransformFu
  * x.val = 6; // no log
  * ```
  */
-export function effect<W extends Record<string, WeakKey>|undefined>(handler:W extends undefined ? () => void :(weakVariables: W) => void, weakVariables?: W): {dispose: () => void, [Symbol.dispose]: () => void} {
+export function effect<W extends Record<string, WeakKey>|undefined>(handler:W extends undefined ? () => void|Promise<void> :(weakVariables: W) => void|Promise<void>, weakVariables?: W): {dispose: () => void, [Symbol.dispose]: () => void} {
     
 	let ptr: Pointer;
+
+	// make sure handler is not an async function
+	if (handler.constructor.name == "AsyncFunction") {
+		throw new Error("Async functions are not allowed as effect handlers")
+	}
 
 	// weak variable binding
 	if (weakVariables) {

--- a/functions.ts
+++ b/functions.ts
@@ -31,7 +31,13 @@ export function always<T>(transform:SmartTransformFunction<T>, options?: SmartTr
 export function always<T=unknown>(script:TemplateStringsArray, ...vars:any[]): Promise<MinimalJSRef<T>>
 export function always(scriptOrJSTransform:TemplateStringsArray|SmartTransformFunction<any>, ...vars:any[]) {
     // js function
-    if (typeof scriptOrJSTransform == "function") return Ref.collapseValue(Pointer.createSmartTransform(scriptOrJSTransform, undefined, undefined, undefined, vars[0]));
+    if (typeof scriptOrJSTransform == "function") {
+		// make sure handler is not an async function
+		if (scriptOrJSTransform.constructor.name == "AsyncFunction") {
+			throw new Error("Async functions are not allowed as always transforms")
+		}
+		return Ref.collapseValue(Pointer.createSmartTransform(scriptOrJSTransform, undefined, undefined, undefined, vars[0]));
+	}
     // datex script
     else return (async ()=>Ref.collapseValue(await datex(`always (${scriptOrJSTransform.raw.join(INSERT_MARK)})`, vars)))()
 }

--- a/js_adapter/js_class_adapter.ts
+++ b/js_adapter/js_class_adapter.ts
@@ -574,9 +574,11 @@ export class Decorators {
 function normalizeType(type:Type|string, allowTypeParams = true, defaultNamespace = "std") {
     if (typeof type == "string") {
         // extract type name and parameters
-        const [typeName, paramsString] = type.replace(/^\</,'').replace(/\>$/,'').match(/^((?:\w+\:)?\w*)(?:\((.*)\))?$/)?.slice(1) ?? [];
+        const [typeName, paramsString] = type.replace(/^\</,'').replace(/\>$/,'').match(/^((?:[\w-]+\:)?[\w-]*)(?:\((.*)\))?$/)?.slice(1) ?? [];
         if (paramsString && !allowTypeParams) throw new Error(`Type parameters not allowed (${type})`);
         
+        if (!typeName) throw new Error("Invalid type: " + type);
+
         // TODO: only json-compatible params are allowed for now to avoid async
         const parsedParams = paramsString ? JSON.parse(`[${paramsString}]`) : undefined;
         return Type.get(typeName.includes(":") ? typeName : defaultNamespace+":"+typeName, parsedParams)

--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -2254,7 +2254,10 @@ export class Pointer<T = any> extends Ref<T> {
         }
         //placeholder replacement
         if (Pointer.pointer_value_map.has(v)) {
-            if (this.#loaded) {throw new PointerError("Cannot assign a new value to an already initialized pointer")}
+            if (this.#loaded) {
+                console.log("value",v)
+                throw new PointerError("Cannot assign a new value to an already initialized pointer")
+            }
             const existing_pointer = Pointer.pointer_value_map.get(v)!;
             existing_pointer.unPlaceholder(this.id) // no longer placeholder, this pointer gets 'overriden' by existing_pointer
             return existing_pointer;


### PR DESCRIPTION
The original motivation for this PR was the ability to execute async effects sequentially.

Example:
```ts
effect(() => {
   const name = search.name;
   return searchPerson(name).then(person => {
      console.log("found person", person);
      displayPerson(person);
   })	
})
```

In this scenario, we have an input field that is bound to `search.name`. With the current implementation of effect, it is not guaranteed that after the last call to `displayPerson`, the person matching the search input is actually displayed, because multiple effects are triggered in parallel for each search input change, and are not guaranteed to resolve in the order they where intially triggered due to the async call.

This PR solves this problem by introducing *sequential async effects* (See docs)
Additionally, by reusing the new functionality added for effects, we can now also support `asyncAlways`, but with some limitations (The usage might also be a bit confusing sometimes) (See docs)
