### PR TITLE
Storage memory management

### DIFF
--- a/compiler/compiler.ts
+++ b/compiler/compiler.ts
@@ -2017,8 +2017,7 @@ export class Compiler {
                 SCOPE.addJSTypeDefs = receiver != Runtime.endpoint && receiver != LOCAL_ENDPOINT;
             }
 
-            // add js type module only if http(s) url
-            const addTypeDefs = SCOPE.addJSTypeDefs && jsTypeDefModule && (jsTypeDefModule.toString().startsWith("http://") || jsTypeDefModule.toString().startsWith("https://"));
+            const addTypeDefs = SCOPE.addJSTypeDefs && jsTypeDefModule;
 
             if (addTypeDefs) {
                 Compiler.builder.handleRequiredBufferSize(SCOPE.b_index+4, SCOPE);

--- a/docs/manual/04 Pointer Synchronisation.md
+++ b/docs/manual/04 Pointer Synchronisation.md
@@ -167,3 +167,39 @@ const x2 = await $.ABCDEF
 assert (x1 === x2)
 ```
 
+The identity of a pointer is always preserved. Even if you receive the pointer
+from a remote endpoint call, it is still identical to the local instance:
+
+```ts
+// remote endpoint
+
+type User = {name: string, age: number}
+
+const happyBirthday = $$(
+   function (user: User) {
+      user.age++;
+      return user;
+   }
+)
+```
+
+```ts
+// local endpoint
+
+const user = $$({
+   name: "Luke",
+   age: 20
+})
+
+const happyBirthday = await $.DEFABCDEF // <- pointer id for the remote "happyBirthday" function
+const olderUser = await happyBirthday(user);
+
+user === olderUser // true
+olderUser.age === 21 // true
+user.age === 21 // true
+```
+
+Like we would expect if this was a normal, local JavaScript function call, the returned
+`user` object is identical to the object we passed to the function.
+This is not only true for this simple example, but also for more complex scenarios.
+For example, reference identities are also preserved within [eternal values](./05%20Eternal%20Pointers.md).

--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -1394,13 +1394,16 @@ export class Pointer<T = any> extends Ref<T> {
             }
 
             if (stored!=NOT_EXISTING) {
-                // if the value is a pointer with a tranform scope, copy the transform, not the value (TODO still just a workaround to preserve transforms in storage, maybe better solution?)
-                if (stored instanceof Pointer && stored.transform_scope) {
-                    await pointer.handleTransformAsync(stored.transform_scope.internal_vars, stored.transform_scope);
+                // set value if pointer still not loaded during source.getPointer
+                if (!pointer.#loaded) {
+                    // if the value is a pointer with a tranform scope, copy the transform, not the value (TODO still just a workaround to preserve transforms in storage, maybe better solution?)
+                    if (stored instanceof Pointer && stored.transform_scope) {
+                        await pointer.handleTransformAsync(stored.transform_scope.internal_vars, stored.transform_scope);
+                    }
+                    // set normal value
+                    else pointer = pointer.setValue(stored);
                 }
-                // set normal value
-                else pointer = pointer.setValue(stored);
-
+               
                 // now sync if source (pointer storage) can sync pointer
                 if (source?.syncPointer) source.syncPointer(pointer);
 

--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -1198,7 +1198,8 @@ export class Pointer<T = any> extends Ref<T> {
         // update pointer ids if no longer local
         if (!this.#is_local) {
             for (const pointer of this.#local_pointers) {
-                pointer.id = Pointer.getUniquePointerID(pointer);
+                // still local?
+                if (pointer.origin == LOCAL_ENDPOINT) pointer.id = Pointer.getUniquePointerID(pointer);
             }
             this.#local_pointers.clear();
         }

--- a/runtime/storage.ts
+++ b/runtime/storage.ts
@@ -380,6 +380,7 @@ export class Storage {
 
     static setItem(key:string, value:any, listen_for_pointer_changes = true, location:StorageLocation|null|undefined = this.#primary_location):Promise<boolean>|boolean {
         Storage.cache.set(key, value); // save in cache
+
         // cache deletion does not work, problems with storage item backup
         // setTimeout(()=>Storage.cache.delete(key), 10000);
 
@@ -845,6 +846,7 @@ export class Storage {
 
 		Storage.cache.set(key, val);
 		await this.initItemFromTrustedLocation(key, val, location)
+
 		return val;
     }
 
@@ -1031,7 +1033,7 @@ export class Storage {
     }
 
     public static async printSnapshot(options: StorageSnapshotOptions = {internalItems: false, expandStorageMapsAndSets: true}) {
-        const {items, pointers} = await this.getSnapshot();
+        const {items, pointers} = await this.getSnapshot(options);
 
         const COLOR_PTR = `\x1b[38;2;${[65,102,238].join(';')}m`
         const COLOR_NUMBER = `\x1b[38;2;${[253,139,25].join(';')}m`
@@ -1149,11 +1151,9 @@ export class Storage {
         const items = await this.createSnapshot(this.getItemKeys.bind(this), this.getItemDecompiled.bind(this));
         const pointers = await this.createSnapshot(this.getPointerKeys.bind(this), this.getPointerDecompiledFromLocation.bind(this));
 
-        // remove internal items
-        if (!options.internalItems) {
-            for (const [key] of items.snapshot) {
-                if (key.startsWith("keys_")) items.snapshot.delete(key);
-            }
+        // remove keys items that are unrelated to normal storage
+        for (const [key] of items.snapshot) {
+            if (key.startsWith("keys_")) items.snapshot.delete(key);
         }
 
         // iterate over storage maps and sets and render all entries

--- a/runtime/storage.ts
+++ b/runtime/storage.ts
@@ -447,6 +447,7 @@ export class Storage {
 
         const dependencies = await this.updatePointerAsync(location, pointer, partialUpdateKey);
         dependencies.delete(pointer);
+        this.updatePointerDependencies(pointer.id, [...dependencies].map(p=>p.id));
         await this.saveDependencyPointersAsync(dependencies, listen_for_changes, location);
 
         // listen for changes
@@ -690,6 +691,10 @@ export class Storage {
             // clear dependencies
             this.updatePointerDependencies(pointer_id, [])
 
+            const ptr = Pointer.get(pointer_id)
+            if (ptr) this.#storage_active_pointers.delete(ptr);
+            this.#storage_active_pointer_ids.delete(pointer_id);
+
 			for (const location of this.#locations.keys()) {
 				await location.removePointer(pointer_id);
 			}
@@ -873,7 +878,7 @@ export class Storage {
 		if (location) return location.removeItem(key);
 		// remove from all
 		else {
-            if (Storage.cache.has(key)) Storage.cache.delete(key); // delete from cache
+            Storage.cache.delete(key); // delete from cache
             
             // clear dependencies
             this.updateItemDependencies(key, [])

--- a/runtime/storage.ts
+++ b/runtime/storage.ts
@@ -646,15 +646,22 @@ export class Storage {
 
         // create pointer with saved id and value + start syncing, if pointer not already created in DATEX
         if (pointerify) {
-            let pointer: Pointer;
+            let pointer = Pointer.get(pointer_id)
 
             // if the value is a pointer with a tranform scope, copy the transform, not the value (TODO still just a workaround to preserve transforms in storage, maybe better solution?)
             if (val instanceof Pointer && val.transform_scope) {
                 console.log("init value",val);
                 pointer = await Pointer.createTransformAsync(val.transform_scope.internal_vars, val.transform_scope);
             }
-            // normal pointer from value
-            else pointer = Pointer.create(pointer_id, val, false, Runtime.endpoint);
+            // set value of existing pointer
+            else if (pointer) {
+                if (pointer.value_initialized) logger.warn("pointer value " + pointer.idString() + " already initialized, setting new value from storage");
+                pointer = pointer.setValue(val);
+            }
+            // create new pointer from value
+            else {
+                pointer = Pointer.create(pointer_id, val, false, Runtime.endpoint);
+            }
 
             this.syncPointer(pointer);
             this.#storage_active_pointers.add(pointer);

--- a/types/native_types.ts
+++ b/types/native_types.ts
@@ -278,6 +278,11 @@ Type.std.Set.setJSInterface({
     get_property: (parent:Set<any>, key) => NOT_EXISTING,
     has_property: (parent:Set<any>, key) => parent.has(key),
 
+    // implemented to support self-referencing serialization, not actual properties
+    // small issue with this approach: the Set always contains 'undefined'
+    set_property_silently: (parent:Set<unknown>, key, value, pointer) => Set.prototype.add.call(parent, value),
+    set_property: (parent:Set<unknown>, key, value) => parent.add(value),
+
 
     count: (parent:Set<any>) => parent.size,
     keys: (parent:Set<any>) => [...parent],

--- a/types/storage_map.ts
+++ b/types/storage_map.ts
@@ -11,10 +11,10 @@ const logger = new Logger("StorageMap");
 
 /**
  * WeakMap that outsources values to storage.
- * In contrast to JS WeakMaps, primitive keys are also allowed
- * Entries are not automatically garbage collected but must be
- * explicitly deleted
- * all methods are async
+ * The API is similar to the JS WeakMap API, but all methods are async.
+ * In contrast to JS WeakMaps, primitive keys are also allowed.
+ * The StorageWeakMap holds no strong references to its keys in storage.
+ * This means that the pointer of a key can be garbage collected.
  */
 export class StorageWeakMap<K,V> {
 
@@ -95,7 +95,8 @@ export class StorageWeakMap<K,V> {
 }
 
 /**
- * Map that outsources values to storage.
+ * Set that outsources values to storage.
+ * The API is similar to the JS Map API, but all methods are async.
  */
 export class StorageMap<K,V> extends StorageWeakMap<K,V> {
 

--- a/types/storage_map.ts
+++ b/types/storage_map.ts
@@ -21,8 +21,7 @@ export class StorageWeakMap<K,V> {
 	#prefix?: string;
 
 	constructor(){
-		// TODO: does not work with eternal pointers!
-		// Pointer.proxifyValue(this)
+		Pointer.proxifyValue(this)
 	}
 
 
@@ -32,9 +31,8 @@ export class StorageWeakMap<K,V> {
 		return map;
 	}
 
-	get prefix() {
-		// @ts-ignore
-		if (!this.#prefix) this.#prefix = 'dxmap::'+this[DX_PTR].idString()+'.';
+	protected get _prefix() {
+		if (!this.#prefix) this.#prefix = 'dxmap::'+(this as any)[DX_PTR].idString()+'.';
 		return this.#prefix;
 	}
 
@@ -83,12 +81,12 @@ export class StorageWeakMap<K,V> {
 	protected async getStorageKey(key: K) {
 		const keyHash = await Compiler.getUniqueValueIdentifier(key);
 		// @ts-ignore DX_PTR
-		return this.prefix + keyHash;
+		return this._prefix + keyHash;
 	}
 
 	async clear() {
 		const promises = [];
-		for (const key of await Storage.getItemKeysStartingWith(this.prefix)) {
+		for (const key of await Storage.getItemKeysStartingWith(this._prefix)) {
 			promises.push(await Storage.removeItem(key));
 		}
 		await Promise.all(promises);
@@ -128,11 +126,14 @@ export class StorageMap<K,V> extends StorageWeakMap<K,V> {
 		return Storage.removeItem(storage_item_key)
 	}
 
+	/**
+	 * Async iterator that returns all keys.
+	 */
 	keys() {
 		const self = this;
 		const key_prefix = this.#key_prefix;
 		return (async function*(){
-			const keyGenerator = await Storage.getItemKeysStartingWith(self.prefix);
+			const keyGenerator = await Storage.getItemKeysStartingWith(self._prefix);
 			
 			for (const key of keyGenerator) {
 				const keyValue = await Storage.getItem(key_prefix+key);
@@ -140,16 +141,24 @@ export class StorageMap<K,V> extends StorageWeakMap<K,V> {
 			}
 		})()
 	}
+
+	/**
+	 * Returns an array containing all keys.
+	 * This can be used to iterate over the keys without using a (for await of) loop.
+	 */
 	async keysArray() {
 		const keys = [];
 		for await (const key of this.keys()) keys.push(key);
 		return keys;
 	}
 
+	/**
+	 * Async iterator that returns all values.
+	 */
 	values() {
 		const self = this;
 		return (async function*(){
-			const keyGenerator = await Storage.getItemKeysStartingWith(self.prefix);
+			const keyGenerator = await Storage.getItemKeysStartingWith(self._prefix);
 			
 			for (const key of keyGenerator) {
 				const value = await Storage.getItem(key);
@@ -157,15 +166,28 @@ export class StorageMap<K,V> extends StorageWeakMap<K,V> {
 			}
 		})()
 	}
+
+	/**
+	 * Returns an array containing all values.
+	 * This can be used to iterate over the values without using a (for await of) loop.
+	 */
 	async valuesArray() {
 		const values = [];
 		for await (const value of this.values()) values.push(value);
 		return values;
 	}
 
+	/**
+	 * Async iterator that returns all entries.
+	 */
 	entries() {
 		return this[Symbol.asyncIterator]()
 	}
+
+	/**
+	 * Returns an array containing all entries.
+	 * This can be used to iterate over the entries without using a (for await of) loop.
+	 */
 	async entriesArray() {
 		const entries = [];
 		for await (const entry of this.entries()) entries.push(entry);
@@ -173,7 +195,7 @@ export class StorageMap<K,V> extends StorageWeakMap<K,V> {
 	}
 
 	async *[Symbol.asyncIterator]() {
-		const keyGenerator = await Storage.getItemKeysStartingWith(this.prefix);
+		const keyGenerator = await Storage.getItemKeysStartingWith(this._prefix);
 		
 		for (const key of keyGenerator) {
 			const keyValue = await Storage.getItem(this.#key_prefix+key);
@@ -184,7 +206,7 @@ export class StorageMap<K,V> extends StorageWeakMap<K,V> {
 
 	override async clear() {
 		const promises = [];
-		for (const key of await Storage.getItemKeysStartingWith(this.prefix)) {
+		for (const key of await Storage.getItemKeysStartingWith(this._prefix)) {
 			promises.push(await Storage.removeItem(key));
 			promises.push(await Storage.removeItem(this.#key_prefix+key));
 		}

--- a/types/storage_map.ts
+++ b/types/storage_map.ts
@@ -87,7 +87,7 @@ export class StorageWeakMap<K,V> {
 	async clear() {
 		const promises = [];
 		for (const key of await Storage.getItemKeysStartingWith(this._prefix)) {
-			promises.push(await Storage.removeItem(key));
+			promises.push(Storage.removeItem(key));
 		}
 		await Promise.all(promises);
 	}

--- a/types/storage_set.ts
+++ b/types/storage_set.ts
@@ -18,7 +18,7 @@ export class StorageSet<V> {
 
 	constructor(){
 		// TODO: does not work with eternal pointers!
-		// Pointer.proxifyValue(this)
+		Pointer.proxifyValue(this)
 	}
 
 	static async from<V>(values: readonly V[]) {
@@ -66,8 +66,8 @@ export class StorageSet<V> {
 		}, 60_000);
 	}
 
-	protected getStorageKey(value: V) {
-		const keyHash = Compiler.getUniqueValueIdentifier(value);
+	protected async getStorageKey(value: V) {
+		const keyHash = await Compiler.getUniqueValueIdentifier(value);
 		// @ts-ignore DX_PTR
 		return this.prefix + keyHash;
 	}

--- a/types/storage_set.ts
+++ b/types/storage_set.ts
@@ -9,15 +9,17 @@ import { Logger } from "../utils/logger.ts";
 const logger = new Logger("StorageSet");
 
 /**
- * Set that outsources values to storage.
- * all methods are async
+ * WeakSet that outsources values to storage.
+ * The API is similar to the JS WeakSet API, but all methods are async.
+ * In contrast to JS WeakSets, primitive values are also allowed.
+ * The StorageWeakSet holds no strong references to its values in storage.
+ * This means that the pointer of a value can be garbage collected.
  */
-export class StorageSet<V> {
+export class StorageWeakSet<V> {
 
 	#prefix?: string;
 
 	constructor(){
-		// TODO: does not work with eternal pointers!
 		Pointer.proxifyValue(this)
 	}
 
@@ -27,18 +29,17 @@ export class StorageSet<V> {
 		return set;
 	}
 
-	get prefix() {
-		// @ts-ignore
-		if (!this.#prefix) this.#prefix = 'dxset::'+this[DX_PTR].idString()+'.';
+	protected get _prefix() {
+		if (!this.#prefix) this.#prefix = 'dxset::'+(this as any)[DX_PTR].idString()+'.';
 		return this.#prefix;
 	}
 
 	async add(value: V) {
 		const storage_key = await this.getStorageKey(value);
 		if (await this._has(storage_key)) return; // already exists
-		return this._add(storage_key, value);
+		return this._add(storage_key, null);
 	}
-	protected _add(storage_key:string, value:V) {
+	protected _add(storage_key:string, value:V|null) {
 		this.activateCacheTimeout(storage_key);
 		return Storage.setItem(storage_key, value);
 	}
@@ -69,40 +70,76 @@ export class StorageSet<V> {
 	protected async getStorageKey(value: V) {
 		const keyHash = await Compiler.getUniqueValueIdentifier(value);
 		// @ts-ignore DX_PTR
-		return this.prefix + keyHash;
+		return this._prefix + keyHash;
 	}
 
 	async clear() {
 		const promises = [];
-		for (const key of await Storage.getItemKeysStartingWith(this.prefix)) {
+		for (const key of await Storage.getItemKeysStartingWith(this._prefix)) {
 			promises.push(await Storage.removeItem(key));
 		}
 		await Promise.all(promises);
 	}
 
 
+}
+
+/**
+ * Set that outsources values to storage.
+ * The API is similar to the JS Set API, but all methods are async.
+ */
+export class StorageSet<V> extends StorageWeakSet<V> {
+
+	/**
+	 * Appends a new value to the StorageWeakSet.
+	 */
+	async add(value: V) {
+		const storage_key = await this.getStorageKey(value);
+		if (await this._has(storage_key)) return; // already exists
+		return this._add(storage_key, value);
+	}
+
+	/**
+	 * Async iterator that returns all keys.
+	 */
 	keys() {
 		return this[Symbol.asyncIterator]()
 	}
+
+	/**
+	 * Returns an array containing all keys.
+	 * This can be used to iterate over the keys without using a (for await of) loop.
+	 */
 	async keysArray() {
 		const keys = [];
 		for await (const key of this.keys()) keys.push(key);
 		return keys;
 	}
 
+	/**
+	 * Async iterator that returns all values.
+	 */
 	values() {
 		return this[Symbol.asyncIterator]()
 	}
+
+	/**
+	 * Returns an array containing all values.
+	 * This can be used to iterate over the values without using a (for await of) loop.
+	 */
 	async valuesArray() {
 		const values = [];
 		for await (const value of this.values()) values.push(value);
 		return values;
 	}
 
+	/**
+	 * Async iterator that returns all entries.
+	 */
 	entries() {
 		const self = this;
 		return (async function*(){
-			const keyGenerator = await Storage.getItemKeysStartingWith(self.prefix);
+			const keyGenerator = await Storage.getItemKeysStartingWith(self._prefix);
 			
 			for (const key of keyGenerator) {
 				const value = await Storage.getItem(key);
@@ -110,6 +147,11 @@ export class StorageSet<V> {
 			}
 		})()
 	}
+
+	/**
+	 * Returns an array containing all entries.
+	 * This can be used to iterate over the entries without using a (for await of) loop.
+	 */
 	async entriesArray() {
 		const entries = [];
 		for await (const entry of this.entries()) entries.push(entry);
@@ -117,7 +159,7 @@ export class StorageSet<V> {
 	}
 
 	async *[Symbol.asyncIterator]() {
-		const keyGenerator = await Storage.getItemKeysStartingWith(this.prefix);
+		const keyGenerator = await Storage.getItemKeysStartingWith(this._prefix);
 		
 		for (const key of keyGenerator) {
 			const value = await Storage.getItem(key);

--- a/types/type.ts
+++ b/types/type.ts
@@ -56,6 +56,7 @@ export class Type<T = any> extends ExtensibleFunction {
     parameters:any[] // special type parameters
 
     #jsTypeDefModule?: string|URL // URL for the JS module that creates the corresponding type definition
+    #potentialJsTypeDefModule?: string|URL // remember jsTypeDefModule if jsTypeDefModuleMapper is added later
 
     get jsTypeDefModule():string|URL|undefined {return this.#jsTypeDefModule}
     set jsTypeDefModule(url: string|URL) {
@@ -65,6 +66,7 @@ export class Type<T = any> extends ExtensibleFunction {
         else if (url.toString().startsWith("http://") || url.toString().startsWith("https://")) {
             this.#jsTypeDefModule = url;
         }
+        this.#potentialJsTypeDefModule = url;
     }
 
     root_type: Type; // DatexType without parameters and variation
@@ -88,7 +90,7 @@ export class Type<T = any> extends ExtensibleFunction {
         this.#jsTypeDefModuleMapper = fn;
         // update existing typedef modules
         for (const type of this.types.values()) {
-            if (type.#jsTypeDefModule) type.jsTypeDefModule = type.#jsTypeDefModule;
+            if (type.#potentialJsTypeDefModule) type.jsTypeDefModule = type.#potentialJsTypeDefModule;
         }
     }
 

--- a/types/type.ts
+++ b/types/type.ts
@@ -59,8 +59,12 @@ export class Type<T = any> extends ExtensibleFunction {
 
     get jsTypeDefModule():string|URL|undefined {return this.#jsTypeDefModule}
     set jsTypeDefModule(url: string|URL) {
+        // custom module mapper
         if (Type.#jsTypeDefModuleMapper) this.#jsTypeDefModule = Type.#jsTypeDefModuleMapper(url, this);
-        else this.#jsTypeDefModule = url;
+        // default: only allow http/https modules
+        else if (url.toString().startsWith("http://") || url.toString().startsWith("https://")) {
+            this.#jsTypeDefModule = url;
+        }
     }
 
     root_type: Type; // DatexType without parameters and variation

--- a/types/type.ts
+++ b/types/type.ts
@@ -20,7 +20,7 @@ import type { Task } from "./task.ts";
 import { Assertion } from "./assertion.ts";
 import type { Iterator } from "./iterator.ts";
 import {StorageMap, StorageWeakMap} from "./storage_map.ts"
-import {StorageSet} from "./storage_set.ts"
+import {StorageSet, StorageWeakSet} from "./storage_set.ts"
 import { ExtensibleFunction } from "./function-utils.ts";
 import type { JSTransferableFunction } from "./js-function.ts";
 
@@ -1012,6 +1012,7 @@ export class Type<T = any> extends ExtensibleFunction {
         StorageMap: Type.get<StorageMap<unknown, unknown>>("std:StorageMap"),
         StorageWeakMap: Type.get<StorageWeakMap<unknown, unknown>>("std:StorageWeakMap"),
         StorageSet: Type.get<StorageSet<unknown>>("std:StorageSet"),
+        StorageWeakSet: Type.get<StorageWeakSet<unknown>>("std:StorageWeakSet"),
 
         Error: Type.get<Error>("std:Error"),
         SyntaxError: Type.get("std:SyntaxError"),
@@ -1090,6 +1091,13 @@ Type.std.StorageWeakMap.setJSInterface({
 
 Type.std.StorageMap.setJSInterface({
     class: StorageMap,
+    is_normal_object: true,
+    proxify_children: true,
+    visible_children: new Set(),
+})
+
+Type.std.StorageWeakSet.setJSInterface({
+    class: StorageWeakSet,
     is_normal_object: true,
     proxify_children: true,
     visible_children: new Set(),


### PR DESCRIPTION
Closes https://github.com/unyt-org/datex-core-js-legacy/issues/53

This PR implements a garbage collection system for the DATEX pointer storage.
This is a completely separate GC system from the runtime GC, and it is still a quite naive implementation, but it is essential for storage memory management.

The GC is not specific for a storage location, but works with all storage locations (Databases, local storage, indexed db) that implement the `StorageLocation` API. 
It works simultaneously across all storage locations.

*Background:*
When we assume that all eternal pointers exist for "eternity", we don't need any kind of automatic storage management - pointers are added to the storage and updated, but never deleted. Before this PR, a developer could explicitly delete pointers from the storage, but they were not removed when they were no longer needed. This is a big problem for huge collections like maps and sets with lots of volatile, changing data (e.g. temporary log entries).

The basic idea for the new storage GC is to use a basic reference counting (RC) system.
 * If a pointer is still directly or indirectly referenced by a storage item (which is essentially an eternal value binding), it is guaranteed to be kept in the storage.
 * On the other hand, it can't be guaranteed that a pointer will be removed from storage once it is no longer accessible (e.g. when there is a circular reference). This is a fundamental problem of RC - in the future, we might switch to a different, more sophisticated GC algorithm (e.g. mark and sweep).

Addtional new features:
 * Both StorageWeakMap and StorageWeakSets are now supported (with some limitations: https://github.com/unyt-org/datex-core-js-legacy/issues/57)
 * `Datex.Storage.printSnapshot()` can be used for storage analyis and debugging

Initial storage allocations when running `Datex.Storage.printSnapshot()` in a new UIX base project:
![image](https://github.com/unyt-org/datex-core-js-legacy/assets/35869401/296c9914-667b-4586-9368-508764edd3f5)