### PR TITLE
Fix local pointers in storage

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -80,8 +80,8 @@ export async function init() {
 		// has only local endpoint id (%0000) or global id?
 		if (endpoint != LOCAL_ENDPOINT) {
 			Pointer.is_local = false;
-			// update items that contain pointers with unresolved local origin in storage
-			Storage.updateItemsWithUnresolvedLocalDependencies();
+			// update storage entries that contain pointers with unresolved @@local origin
+			Storage.updateEntriesWithUnresolvedLocalDependencies();
 			// init subscriber cache as soon as endpoint is available
 			initSubscriberCache();
 		}

--- a/init.ts
+++ b/init.ts
@@ -80,6 +80,8 @@ export async function init() {
 		// has only local endpoint id (%0000) or global id?
 		if (endpoint != LOCAL_ENDPOINT) {
 			Pointer.is_local = false;
+			// update items that contain pointers with unresolved local origin in storage
+			Storage.updateItemsWithUnresolvedLocalDependencies();
 			// init subscriber cache as soon as endpoint is available
 			initSubscriberCache();
 		}

--- a/runtime/runtime.ts
+++ b/runtime/runtime.ts
@@ -1830,8 +1830,9 @@ export class Runtime {
             }
             // other message, assume sender endpoint is online now
             else {
-                // HELLO message received, regard as new login to network, reset previous subscriptions
-                if (header.type == ProtocolDataType.HELLO && !header.sender.ignoreHello) Pointer.clearEndpointSubscriptions(header.sender)
+                // TODO: HELLO message received, regard as new login to network, reset previous subscriptions? 
+                // does not work correctly because valid subscriptions are reset after HELLO message is received after some time
+                // if (header.type == ProtocolDataType.HELLO && !header.sender.ignoreHello) Pointer.clearEndpointSubscriptions(header.sender)
                 header.sender.setOnline(true)
             }
         }

--- a/runtime/storage.ts
+++ b/runtime/storage.ts
@@ -437,7 +437,7 @@ export class Storage {
      */
     static updateEntriesWithUnresolvedLocalDependencies() {
         for (const [key, value] of this.#unresolvedLocalItems) {
-            logger.debug("update item containing pointers with @@local origin!: " +  key)
+            logger.debug("update item containing pointers with @@local origin: " +  key)
             this.setItem(key, value)
         }
         this.#unresolvedLocalItems.clear()

--- a/runtime/storage.ts
+++ b/runtime/storage.ts
@@ -377,6 +377,8 @@ export class Storage {
         return this.trusted_location;
     }
 
+    static #unresolvedLocalItems = new Map<string, unknown>()
+
 
     static setItem(key:string, value:any, listen_for_pointer_changes = true, location:StorageLocation|null|undefined = this.#primary_location):Promise<boolean>|boolean {
         Storage.cache.set(key, value); // save in cache
@@ -391,22 +393,50 @@ export class Storage {
         else return false;
     }
 
-	static async setItemAsync(location:AsyncStorageLocation, key: string,value: unknown,listen_for_pointer_changes: boolean) {
+	static async setItemAsync(location:AsyncStorageLocation, key: string, value: unknown,listen_for_pointer_changes: boolean) {
         this.setDirty(location, true)
         // store value (might be pointer reference)
         const dependencies = await location.setItem(key, value);
+        if (Pointer.is_local) this.checkUnresolvedLocalDependencies(key, value, dependencies);
         this.updateItemDependencies(key, [...dependencies].map(p=>p.id));
         await this.saveDependencyPointersAsync(dependencies, listen_for_pointer_changes, location);
         this.setDirty(location, false)
         return true;
 	}
 
-	static setItemSync(location:SyncStorageLocation, key: string,value: unknown,listen_for_pointer_changes: boolean) {
+	static setItemSync(location:SyncStorageLocation, key: string, value: unknown,listen_for_pointer_changes: boolean) {
         const dependencies = location.setItem(key, value);
+        if (Pointer.is_local) this.checkUnresolvedLocalDependencies(key, value, dependencies);
         this.updateItemDependencies(key, [...dependencies].map(p=>p.id));
         this.saveDependencyPointersSync(dependencies, listen_for_pointer_changes, location);
         return true;
 	}
+
+    /**
+     * Collects all pointer dependencies of an item with a @@local origin.
+     * Once the endpoint is initialized, the item is updated with the correct pointer ids.
+     * @param itemKey 
+     * @param value 
+     * @param dependencies 
+     */
+    private static checkUnresolvedLocalDependencies(itemKey: string, value:unknown, dependencies: Set<Pointer>) {
+        const hasUnresolvedLocalDependency = [...dependencies].some(p=>p.origin == LOCAL_ENDPOINT);
+        if (hasUnresolvedLocalDependency) {
+            this.#unresolvedLocalItems.set(itemKey, value)  
+        }
+    }
+
+    /**
+     * Updates all items in storage that still are stored with unresolved @@local pointers
+     */
+    static updateItemsWithUnresolvedLocalDependencies() {
+        for (const [key, value] of this.#unresolvedLocalItems) {
+            logger.debug("update item containing pointers with @@local origin: " +  key)
+            this.setItem(key, value)
+        }
+        this.#unresolvedLocalItems.clear()
+    }
+
 
     public static setPointer(pointer:Pointer, listen_for_changes = true, location:StorageLocation|undefined = this.#primary_location, partialUpdateKey: unknown = NOT_EXISTING): Promise<boolean>|boolean {
         if (!pointer.value_initialized) {

--- a/types/addressing.ts
+++ b/types/addressing.ts
@@ -283,7 +283,10 @@ export class Endpoint extends Target {
 		return this.#entrypoint = Runtime.Blockchain.getEndpointDefault(this);
 	}
 
-	public async getAlias(){
+	public async getAlias(useCache = true){
+		// use cached alias
+		if (this.#alias && useCache) return this.#alias;
+
 		// resolve alias from Blockchain
 		try {
 			this.#alias = <string | undefined> await Runtime.Blockchain.resolveAlias(this);


### PR DESCRIPTION
Currently, item or pointer entries might point to pointers with a `@@local` origin in storage, but when the actual endpoint is initialized, the pointer entries are updated and the data in the referencing entry point to invalid data.

With this PR, all entries in storage the reference unresolved `@@local` origin pointers are updated once the actual endpoint is available. 