### PR TITLE
Fix cleanup

### DIFF
--- a/datex_short.ts
+++ b/datex_short.ts
@@ -1,7 +1,7 @@
 
 // shortcut functions
 // import { Datex } from "./datex.ts";
-import { baseURL, Runtime, PrecompiledDXB, Type, Pointer, Ref, PointerProperty, primitive, any_class, Target, IdEndpoint, TransformFunctionInputs, AsyncTransformFunction, TransformFunction, TextRef, Markdown, DecimalRef, BooleanRef, IntegerRef, MinimalJSRef, RefOrValue, PartialRefOrValueObject, datex_meta, ObjectWithDatexValues, Compiler, endpoint_by_endpoint_name, endpoint_name, Storage, compiler_scope, datex_scope, DatexResponse, target_clause, ValueError, logger, Class, getUnknownMeta, Endpoint, INSERT_MARK, CollapsedValueAdvanced, CollapsedValue, SmartTransformFunction, compiler_options, activePlugins, METADATA, handleDecoratorArgs, RefOrValueObject, PointerPropertyParent, InferredPointerProperty, RefLike } from "./datex_all.ts";
+import { baseURL, Runtime, PrecompiledDXB, Type, Pointer, Ref, PointerProperty, primitive, any_class, Target, IdEndpoint, TransformFunctionInputs, AsyncTransformFunction, TransformFunction, Markdown, MinimalJSRef, RefOrValue, PartialRefOrValueObject, datex_meta, ObjectWithDatexValues, Compiler, endpoint_by_endpoint_name, endpoint_name, Storage, compiler_scope, datex_scope, DatexResponse, target_clause, ValueError, logger, Class, getUnknownMeta, Endpoint, INSERT_MARK, CollapsedValueAdvanced, CollapsedValue, SmartTransformFunction, compiler_options, activePlugins, METADATA, handleDecoratorArgs, RefOrValueObject, PointerPropertyParent, InferredPointerProperty, RefLike } from "./datex_all.ts";
 
 /** make decorators global */
 import { assert as _assert, property as _property, sync as _sync, endpoint as _endpoint, template as _template, jsdoc as _jsdoc} from "./datex_all.ts";
@@ -357,25 +357,25 @@ export function val<T>(val: RefOrValue<T>):T  { // TODO: return inferred type in
 
 
 // generate primitive pointers
-export function decimal(value:RefOrValue<number|bigint|string> = 0): DecimalRef {
+export function decimal(value:RefOrValue<number|bigint|string> = 0): Pointer<number> {
     if (value instanceof Ref) value = value.val; // collapse
     return Pointer.create(undefined, Number(value)) // adds pointer or returns existing pointer
 }
-export function integer(value:RefOrValue<bigint|number|string> = 0n): IntegerRef {
+export function integer(value:RefOrValue<bigint|number|string> = 0n): Pointer<bigint> {
     if (value instanceof Ref) value = value.val; // collapse
     return Pointer.create(undefined, BigInt(Math.floor(Number(value)))) // adds pointer or returns existing pointer
 }
-export function text(string:TemplateStringsArray, ...vars:any[]):Promise<TextRef>
-export function text(value?:RefOrValue<any>): TextRef
-export function text(value:RefOrValue<string>|TemplateStringsArray = "", ...vars:any[]): TextRef|Promise<TextRef> {
+export function text(string:TemplateStringsArray, ...vars:any[]):Promise<Pointer<string>>
+export function text(value?:RefOrValue<any>): Pointer<string>
+export function text(value:RefOrValue<string>|TemplateStringsArray = "", ...vars:any[]): Pointer<string>|Promise<Pointer<string>> {
     if (value instanceof Ref) value = value.val; // collapse
     // template transform
     if (value instanceof Array) {
-        return <Promise<TextRef<string>>>_datex(`always '${value.raw.map(s=>s.replace(/\(/g, '\\(').replace(/\'/g, "\\'")).join(INSERT_MARK)}'`, vars)
+        return <Promise<Pointer<string>>>_datex(`always '${value.raw.map(s=>s.replace(/\(/g, '\\(').replace(/\'/g, "\\'")).join(INSERT_MARK)}'`, vars)
     }
     else return Pointer.create(undefined, String(value)) // adds pointer or returns existing pointer
 }
-export function boolean(value:RefOrValue<boolean> = false): BooleanRef {
+export function boolean(value:RefOrValue<boolean> = false): Pointer<boolean> {
     if (value instanceof Ref) value = value.val; // collapse
     return Pointer.create(undefined, Boolean(value)) // adds pointer or returns existing pointer
 }

--- a/functions.ts
+++ b/functions.ts
@@ -4,7 +4,7 @@
  */
 
 
-import { AsyncTransformFunction, BooleanRef, CollapsedValue, CollapsedValueAdvanced, Decorators, INSERT_MARK, METADATA, MaybeObjectRef, MinimalJSRef, Pointer, Ref, RefLike, RefOrValue, Runtime, SmartTransformFunction, SmartTransformOptions, TransformFunction, TransformFunctionInputs, handleDecoratorArgs, logger, primitive } from "./datex_all.ts";
+import { AsyncTransformFunction, CollapsedValue, CollapsedValueAdvanced, Decorators, INSERT_MARK, METADATA, MaybeObjectRef, MinimalJSRef, Pointer, Ref, RefLike, RefOrValue, Runtime, SmartTransformFunction, SmartTransformOptions, TransformFunction, TransformFunctionInputs, handleDecoratorArgs, logger, primitive } from "./datex_all.ts";
 import { Datex } from "./mod.ts";
 import { PointerError } from "./types/errors.ts";
 import { IterableHandler } from "./utils/iterable-handler.ts";
@@ -333,7 +333,7 @@ export function selectProperty<K extends string|number, V>(property:RefLike<K>, 
  * @param value 
  * @returns 
  */
-export function not(value:RefOrValue<boolean>): BooleanRef {
+export function not(value:RefOrValue<boolean>): Pointer<boolean> {
     return transform([value], v=>!v);
 }
 
@@ -342,7 +342,7 @@ export function not(value:RefOrValue<boolean>): BooleanRef {
  * @param values 
  * @returns 
  */
-export function and(...values:RefOrValue<boolean>[]): BooleanRef {
+export function and(...values:RefOrValue<boolean>[]): Pointer<boolean> {
     return transform(values, (...values)=>{
         for (const v of values) {
             if (!v) return false;
@@ -356,7 +356,7 @@ export function and(...values:RefOrValue<boolean>[]): BooleanRef {
  * @param values 
  * @returns 
  */
-export function or(...values:RefOrValue<boolean>[]): BooleanRef {
+export function or(...values:RefOrValue<boolean>[]): Pointer<boolean> {
     return transform(values, (...values)=>{
         for (const v of values) {
             if (v) return true;

--- a/runtime/lazy-pointer.ts
+++ b/runtime/lazy-pointer.ts
@@ -11,8 +11,8 @@ export class LazyPointer<T> {
 		Pointer.onPointerForIdAdded(this.id, p => callback(Pointer.collapseValue(p) as MinimalJSRef<T>, p))
 	}
 
-	static withVal(val:any, callback:(val:MinimalJSRef<unknown>)=>void) {
+	static withVal<T>(val:MinimalJSRef<T>, callback:(val:MinimalJSRef<T>)=>void) {
 		if (val instanceof LazyPointer) val.onLoad(callback);
-		else callback(val, val);
+		else callback(val);
 	}
 }

--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -825,7 +825,7 @@ export type JSValueWith$<T> = ObjectRef<T>;
 export type MinimalJSRef<T, _C = CollapsedValue<T>> =
     _C extends symbol ? symbol : (
         _C extends number|string|boolean|bigint ?
-            T: // keep pointer reference
+            Pointer<_C>: // keep pointer reference
             ObjectRef<_C> // collapsed object
     )
 

--- a/runtime/runtime.ts
+++ b/runtime/runtime.ts
@@ -27,7 +27,7 @@ Symbol.prototype.toJSON = function(){return globalThis.String(this)}
 
 /***** imports */
 import { Compiler, compiler_options, PrecompiledDXB, ProtocolDataTypesMap, DatexResponse} from "../compiler/compiler.ts"; // Compiler functions
-import { DecimalRef, IntegerRef, Pointer, PointerProperty, RefOrValue, Ref, TextRef, BooleanRef, ObjectWithDatexValues, JSValueWith$, MinimalJSRef, ObjectRef, RefLike, UpdateScheduler} from "./pointers.ts";
+import { Pointer, PointerProperty, RefOrValue, Ref, ObjectWithDatexValues, JSValueWith$, MinimalJSRef, ObjectRef, RefLike, UpdateScheduler} from "./pointers.ts";
 import { Endpoint, endpoints, IdEndpoint, LOCAL_ENDPOINT, Target, target_clause, WildcardTarget } from "../types/addressing.ts";
 import { RuntimePerformance } from "./performance_measure.ts";
 import { NetworkError, PermissionError, PointerError, RuntimeError, SecurityError, ValueError, Error as DatexError, CompilerError, TypeError, SyntaxError, AssertionError } from "../types/errors.ts";
@@ -851,7 +851,7 @@ export class Runtime {
      * @param forceLocalExecution execute block even if receiver is external (default false)
      * @returns evaluated DATEX result
      */
-    public static async executeDXBLocally(dxb:ArrayBuffer, context_location?:URL, overrideMeta?: Partial<datex_meta>, forceLocalExecution = false):Promise<any> {
+    public static async executeDXBLocally(dxb:ArrayBuffer, context_location?:URL, overrideMeta?: Partial<datex_meta>, forceLocalExecution = false):Promise<unknown> {
         // generate new header using executor scope header
         let header:dxb_header;
         let dxb_body:ArrayBuffer;
@@ -3865,16 +3865,19 @@ export class Runtime {
                 const value_prim = Ref.collapseValue(value,true,true); // DatexPrimitivePointers also collapsed
                 try {
 
+                    const currentValIsIntegerRef = current_val instanceof Ref && typeof current_val.val == "bigint";
+                    const currentValIsDecimalRef = current_val instanceof Ref && typeof current_val.val == "number";
+
                     // x.current_val ?= value
                     switch (action_type) {
 
                         case BinaryCode.ADD:
                             if (current_val instanceof Array && !(current_val instanceof Tuple)) current_val.push(value); // Array push (TODO array extend?)
-                            else if (current_val instanceof TextRef && typeof value_prim == "string") await current_val.setVal(current_val.val + value); // primitive pointer operations
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val + value_prim);
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val + value_prim);
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val + Number(value_prim));
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
+                            else if (current_val instanceof Ref && typeof current_val.val == "string" && typeof value_prim == "string") await current_val.setVal(current_val.val + value_prim); // primitive pointer operations
+                            else if (currentValIsDecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val + value_prim);
+                            else if (currentValIsIntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val + value_prim);
+                            else if (currentValIsDecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val + Number(value_prim));
+                            else if (currentValIsIntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
                             else if (typeof current_val_prim == "number" && typeof value_prim == "number") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim+value_prim) // add
                             else if ((typeof current_val_prim == "number" && typeof value_prim == "bigint") || (typeof current_val_prim == "bigint" && typeof value_prim == "number")) Runtime.runtime_actions.setProperty(SCOPE, parent, key, Number(current_val_prim)+Number(value_prim)) // add
                             else if (typeof current_val_prim == "bigint" && typeof value_prim == "bigint") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim+value_prim) // add
@@ -3891,10 +3894,10 @@ export class Runtime {
 
                         case BinaryCode.SUBTRACT:
                             if (current_val instanceof Array) Runtime.runtime_actions._removeItemFromArray(current_val, value); // Array splice
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val - value_prim); // primitive pointer operations
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val - value_prim);
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val - Number(value_prim));
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
+                            else if (currentValIsDecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val - value_prim); // primitive pointer operations
+                            else if (currentValIsIntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val - value_prim);
+                            else if (currentValIsDecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val - Number(value_prim));
+                            else if (currentValIsIntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
                             else if (typeof current_val_prim == "number" && typeof value_prim == "number") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim-value_prim) // subtract
                             else if ((typeof current_val_prim == "number" && typeof value_prim == "bigint") || (typeof current_val_prim == "bigint" && typeof value_prim == "number")) Runtime.runtime_actions.setProperty(SCOPE, parent, key, Number(current_val_prim)-Number(value_prim)) // subtract
                             else if (typeof current_val_prim == "bigint" && typeof value_prim == "bigint") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim-value_prim) // subtract
@@ -3909,10 +3912,10 @@ export class Runtime {
                             break;
 
                         case BinaryCode.MULTIPLY:
-                            if (current_val instanceof DecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val * value_prim); // primitive pointer operations
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val * value_prim);
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val * Number(value_prim));
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
+                            if (currentValIsDecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val * value_prim); // primitive pointer operations
+                            else if (currentValIsIntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val * value_prim);
+                            else if (currentValIsDecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val * Number(value_prim));
+                            else if (currentValIsIntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
                             else if (typeof current_val_prim == "number" && typeof value_prim == "number") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim*value_prim) // subtract
                             else if ((typeof current_val_prim == "number" && typeof value_prim == "bigint") || (typeof current_val_prim == "bigint" && typeof value_prim == "number")) Runtime.runtime_actions.setProperty(SCOPE, parent, key, Number(current_val_prim)*Number(value_prim)) // subtract
                             else if (typeof current_val_prim == "bigint" && typeof value_prim == "bigint") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim*value_prim) // subtract
@@ -3927,10 +3930,10 @@ export class Runtime {
                             break;
 
                         case BinaryCode.DIVIDE:
-                            if (current_val instanceof DecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val / value_prim); // primitive pointer operations
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val / value_prim);
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val / Number(value_prim));
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
+                            if (currentValIsDecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val / value_prim); // primitive pointer operations
+                            else if (currentValIsIntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val / value_prim);
+                            else if (currentValIsDecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val / Number(value_prim));
+                            else if (currentValIsIntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
                             else if (typeof current_val_prim == "number" && typeof value_prim == "number") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim/value_prim) // subtract
                             else if ((typeof current_val_prim == "number" && typeof value_prim == "bigint") || (typeof current_val_prim == "bigint" && typeof value_prim == "number")) Runtime.runtime_actions.setProperty(SCOPE, parent, key, Number(current_val_prim)/Number(value_prim)) // subtract
                             else if (typeof current_val_prim == "bigint" && typeof value_prim == "bigint") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim/value_prim) // subtract
@@ -3945,13 +3948,13 @@ export class Runtime {
                             break;
 
                         case BinaryCode.POWER:
-                            if (current_val instanceof DecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val ** value_prim); // primitive pointer operations
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "bigint") {
+                            if (currentValIsDecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val ** value_prim); // primitive pointer operations
+                            else if (currentValIsIntegerRef && typeof value_prim == "bigint") {
                                 if (value_prim < 0) throw new ValueError("Cannot use a negative exponent with an integer")
                                 else current_val.val = current_val.val ** value_prim;
                             }
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val ** Number(value_prim));
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
+                            else if (currentValIsDecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val ** Number(value_prim));
+                            else if (currentValIsIntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
                             else if (typeof current_val_prim == "number" && typeof value_prim == "number") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim**value_prim) // power
                             else if ((typeof current_val_prim == "number" && typeof value_prim == "bigint") || (typeof current_val_prim == "bigint" && typeof value_prim == "number")) Runtime.runtime_actions.setProperty(SCOPE, parent, key, Number(current_val_prim)**Number(value_prim)) // power
                             else if (typeof current_val_prim == "bigint" && typeof value_prim == "bigint") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim**value_prim) // power
@@ -3966,10 +3969,10 @@ export class Runtime {
                             break;
 
                         case BinaryCode.MODULO:
-                            if (current_val instanceof DecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val % value_prim); // primitive pointer operations
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val % value_prim);
-                            else if (current_val instanceof DecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val % Number(value_prim));
-                            else if (current_val instanceof IntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
+                            if (currentValIsDecimalRef && typeof value_prim == "number") await current_val.setVal(current_val.val % value_prim); // primitive pointer operations
+                            else if (currentValIsIntegerRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val % value_prim);
+                            else if (currentValIsDecimalRef && typeof value_prim == "bigint") await current_val.setVal(current_val.val % Number(value_prim));
+                            else if (currentValIsIntegerRef && typeof value_prim == "number") throw new ValueError("Cannot apply a <decimal> value to an <integer> pointer", SCOPE);
                             else if (typeof current_val_prim == "number" && typeof value_prim == "number") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim%value_prim) // subtract
                             else if ((typeof current_val_prim == "number" && typeof value_prim == "bigint") || (typeof current_val_prim == "bigint" && typeof value_prim == "number")) Runtime.runtime_actions.setProperty(SCOPE, parent, key, Number(current_val_prim)%Number(value_prim)) // subtract
                             else if (typeof current_val_prim == "bigint" && typeof value_prim == "bigint") Runtime.runtime_actions.setProperty(SCOPE, parent, key, current_val_prim%value_prim) // subtract


### PR DESCRIPTION
* Fixes some TS errors in runtime.ts and pointers.ts (https://github.com/unyt-org/datex-core-js-legacy/issues/48)
* Removes all primitive pointer classes (e.g `TextRef`, `DecimalRef`) - just using Pointer for all, which simplifies a lot of stuff - primitive pointer classes never really had any benefits