### PR TITLE
Add support for custom blockchain relay endpoints

### DIFF
--- a/network/blockchain_adapter.ts
+++ b/network/blockchain_adapter.ts
@@ -1,5 +1,5 @@
-import { Datex, instance } from "../mod.ts";
-import { Endpoint } from "../datex_all.ts";
+import { Datex, f, instance } from "../mod.ts";
+import { Disjunction, Endpoint } from "../datex_all.ts";
 import {endpoint, property} from "../datex_all.ts";
 import { Logger } from "../utils/logger.ts";
 
@@ -98,8 +98,18 @@ export type BCData<T extends BCEntryType> =
 /**
  * Blockchain interface (using @+unyt2 relay node)
  */
+const relayNode = new Disjunction(f('@+unyt2'));
 
-@endpoint('@+unyt2') export class Blockchain {
+@endpoint(relayNode) export class Blockchain {
+
+	static setRelayNode(node: Endpoint) {
+		logger.debug("using blockchain relay node: " + node);
+		relayNode.clear();
+		relayNode.add(node);
+	}
+	static getRelayNode() {
+		return [...relayNode][0];
+	}
 
 	/**
 	 * Methods that must be implemented on an endpoint that has access to the blockchain:#

--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -2607,12 +2607,12 @@ export class Pointer<T = any> extends Ref<T> {
 
         // propagate updates via datex
         if (this.send_updates_to_origin) {
-            this.handleDatexUpdate(null, '#0=?;? = #0', [this.current_val, this], this.origin, true)
+            this.handleDatexUpdate(null, '#0 = ?; ? = #0', [this.current_val, this], this.origin, true)
         }
         if (this.update_endpoints.size) {
             logger.debug("forwarding update to subscribers", this.update_endpoints);
             // console.log(this.#update_endpoints);
-            this.handleDatexUpdate(null, '#0=?;? = #0', [this.current_val, this], this.update_endpoints, true)
+            this.handleDatexUpdate(null, '#0 = ?; ? = #0', [this.current_val, this], this.update_endpoints, true)
         }
 
         // pointer value change listeners


### PR DESCRIPTION
Currently, the blockchain relay node `@+unyt2` is hard coded as the only blockchain relay node.
Now, it possible to specify a custom blockchain relay node in the `.dx` config file:

```dx
blockchain_relay: @+my-custom-relay
```