### PR TITLE
Fix subscriber caches

### DIFF
--- a/datex_short.ts
+++ b/datex_short.ts
@@ -528,6 +528,7 @@ export function printTrace(endpoint: string|Endpoint) {
 type printTraceT = typeof printTrace;
 declare global {
     const printTrace: printTraceT;
+    const printSnapshot: typeof Storage.printSnapshot
 }
 
 
@@ -654,5 +655,7 @@ globalThis.static_pointer = static_pointer;
 globalThis.f = f;
 // @ts-ignore
 globalThis.printTrace = printTrace;
+// @ts-ignore
+globalThis.printSnapshot = Storage.printSnapshot.bind(Storage);
 // @ts-ignore
 globalThis.props = props;

--- a/network/client.ts
+++ b/network/client.ts
@@ -848,14 +848,14 @@ export class InterfaceManager {
         // iterate over all active endpoints
         for (const interf of CommonInterface.proxy_interface ? [CommonInterface.proxy_interface]: this.active_interfaces) {
             if (interf.endpoint && !exclude_endpoints.has(interf.endpoint) && !interf.endpoint.equals(Runtime.endpoint)) {
-            exclude_endpoints.add(interf.endpoint);
-            //console.log("FLOOD > " + interf.endpoint)
-            interf.send(datex, interf.endpoint);
+                exclude_endpoints.add(interf.endpoint);
+                // console.log("FLOOD > " + interf.endpoint)
+                interf.send(datex, interf.endpoint);
             }
             for (const endpoint of interf.endpoints??[]){
                 if (!exclude_endpoints.has(endpoint) && !interf.endpoint?.equals(Runtime.endpoint)) {
                     exclude_endpoints.add(endpoint);
-                    //console.log("FLOOD > " + endpoint)
+                    // console.log("FLOOD > " + endpoint)
                     interf.send(datex, endpoint);
                 }
             }

--- a/runtime/runtime.ts
+++ b/runtime/runtime.ts
@@ -2216,9 +2216,6 @@ export class Runtime {
     // Persistant Scope Memory
     static persistent_memory:AutoMap<string,{[key:number|string]:any}>;
 
-    // Persistent Pointer subscriber cache (ptr id -> subscribers)
-    static subscriber_cache:AutoMap<string, Set<Endpoint>>;
-
     static saveScopeMemoryValue(scope_identifier:string, key:string|number, value: any) {
         logger.debug("saving persistent memory location ? for ?: ?", key, scope_identifier, value)
         if (this.persistent_memory) this.persistent_memory.getAuto(scope_identifier)[key] = value;


### PR DESCRIPTION
This PR improves persistent subscriber caches.
Subscriber caches in storage are now automatically handled by the `Datex.Storage` manager and are automatically removed when a pointer is no longer stored in storage.