### PR TITLE
Fix pointer property capture

### DIFF
--- a/runtime/pointers.ts
+++ b/runtime/pointers.ts
@@ -622,9 +622,10 @@ export class PointerProperty<T=any> extends Ref<T> {
 
     // get current pointer property
     public override get val():T {
-        // this.handleBeforePrimitiveValueGet();
         if (this.lazy_pointer) return undefined as T
-
+        
+        // capture property access in parent pointer
+        this.pointer!.handleBeforeNonReferencableGet(this.key);
         const val = this.pointer!.getProperty(this.key, this.#leak_js_properties);
         
         if (val === NOT_EXISTING) {


### PR DESCRIPTION
Currently, pointer property access (pp.val) is not captured when determining smart transform dependencies. This is now fixed with this PR.