### PR TITLE
Ignore inline literals in use statements

### DIFF
--- a/runtime/cache_path.ts
+++ b/runtime/cache_path.ts
@@ -7,7 +7,7 @@ let custom_cache_path: string|undefined|-1 = -1;
 export async function _updateCachePaths() {
 	
 	if (custom_cache_path === -1 && client_type == "deno") {
-		const { commandLineOptions } = await import("../utils/args.ts");
+		const { commandLineOptions } = await import("../utils/args.ts" /*lazy*/);
 		custom_cache_path = commandLineOptions.option("cache-path", {aliases: ["c"], type: "string",  description: "Overrides the default path for datex cache files (.datex-cache)"})
 	}
 

--- a/threads/threads.ts
+++ b/threads/threads.ts
@@ -265,7 +265,7 @@ async function registerServiceWorker(path:string|URL) {
  * export const exportedValue = $$([1,2,3]);
  * 
  * /// file: main.ts
- * using thread = await getServiceWorkerThread<typeof import('./sw.ts')>('./sw.ts');
+ * using thread = await getServiceWorkerThread<typeof import('./thread-worker.ts')>('./thread-worker.ts');
  * // access exported values:
  * const res = await thread.exportedFunction(1,2);
  * thread.exportedValue.push(4);
@@ -408,7 +408,7 @@ function freeThread(thread: ThreadModule) {
  * export const exportedValue = $$([1,2,3]);
  * 
  * /// file: main.ts
- * using thread = await spawnThread<typeof import('./thread.ts')>('./thread.ts');
+ * using thread = await spawnThread<typeof import('./threads.ts')>('./threads.ts');
  * // access exported values:
  * const res = await thread.exportedFunction(1,2);
  * thread.exportedValue.push(4);


### PR DESCRIPTION
Inline literals in `use()` declarations can occur when minifying the source code - they should be ignored (https://github.com/unyt-org/datex-core-js-legacy/issues/122)